### PR TITLE
Fixes falsey test for required input check

### DIFF
--- a/TracyDebugger.module.php
+++ b/TracyDebugger.module.php
@@ -3524,7 +3524,7 @@ class TracyDebugger extends WireData implements Module, ConfigurableModule {
         $f->addOption(1, 'True');
         $f->addOption(0, 'False');
         $f->required = true;
-        if($data['codeShowInvisibles']) $f->attr('value', $data['codeShowInvisibles']);
+        if(isset($data['codeShowInvisibles'])) $f->attr('value', $data['codeShowInvisibles']);
         $fieldset->add($f);
 
         $f = $this->wire('modules')->get("InputfieldInteger");
@@ -3544,7 +3544,7 @@ class TracyDebugger extends WireData implements Module, ConfigurableModule {
         $f->addOption(1, 'True');
         $f->addOption(0, 'False');
         $f->required = true;
-        if($data['codeUseSoftTabs']) $f->attr('value', $data['codeUseSoftTabs']);
+        if(isset($data['codeUseSoftTabs'])) $f->attr('value', $data['codeUseSoftTabs']);
         $fieldset->add($f);
 
         $f = $this->wire('modules')->get("InputfieldCheckbox");


### PR DESCRIPTION
`$codeShowInvisibles` and `$codeUseSoftTabs` were not using a strict test to check against having valid data (which in this case could be 0 [zero] for false). Adding `isset` to check if the value is not empty/null so that a zero value does not cause a failure in submission when setting the false value provided in the configuration form for these two options. (NOTE: Tab size theoretically should allow a zero value as well, but what monster would do such a thing?? I left that logic error in place for convention. 😉)