### PR TITLE
fix wrong variable reference in MailInterceptor

### DIFF
--- a/panels/MailInterceptorPanel.php
+++ b/panels/MailInterceptorPanel.php
@@ -190,7 +190,7 @@ class MailInterceptorPanel extends BasePanel {
         $styledAttachments = '';
         if(!is_array($attachments)) $attachments = array($attachments);
         foreach($attachments as $key => $val) {
-            $attachment = is_numeric($key) ? $value : $key;
+            $attachment = is_numeric($key) ? $val : $key;
             $styledAttachments .= '<a href="'.str_replace($this->wire('config')->paths->root, $this->wire('config')->urls->root, $attachment).'">'.str_replace($this->wire('config')->paths->root, '/', $attachment) . '</a><br />';
         }
         return $styledAttachments;


### PR DESCRIPTION
$value was used, but needed to be $val