### PR TITLE
Adminer icon tweaks

### DIFF
--- a/TracyDebugger.module.php
+++ b/TracyDebugger.module.php
@@ -2537,7 +2537,7 @@ class TracyDebugger extends WireData implements Module, ConfigurableModule {
             $link = '';
             // don't add link again unless it's a repeater field
             if(strpos($appendedMarkup, 'adminer_EditFieldLink') === false || $inputfield instanceof InputfieldRepeater) {
-                $link = '<br style="clear: both; visibility: hidden; height:0; margin: 0;" /><a class="adminer_EditFieldLink" style="display: block; float: right; line-height:14px;" title="Edit in Adminer" href="adminer://?'.$adminerQuery.'">'.$adminerIcon.'</a>';
+                $link = '<div class="wrap_adminer_EditFieldLink"><a class="adminer_EditFieldLink" title="Edit in Adminer" href="adminer://?'.$adminerQuery.'">'.$adminerIcon.'</a></div>';
             }
 
             $inputfield->appendMarkup = $inputfield->appendMarkup . $link;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1217,7 +1217,7 @@ ul.pw-info-links {
 }
 
 .tracy-file-tree > ul {
-	margin-left: 0 !important;
+    margin-left: 0 !important;
 }
 
 .tracy-mode-rollup .tracy-filterbox-wrap {
@@ -1235,13 +1235,13 @@ ul.pw-info-links {
 }
 
 .tracy-file-tree a:before {
-	font-size: 13px !important;
+    font-size: 13px !important;
     position: absolute !important;
     left: 0 !important;
 }
 
 .tracy-file-tree a.open:before {
-	content: "\f07c" !important;
+    content: "\f07c" !important;
 }
 
 .tft-d > ul {
@@ -2046,15 +2046,37 @@ https://github.com/ajaxorg/ace/issues/2872
 
 #tracy-debug .tracy-panel-ajax h1::after,
 #tracy-debug .tracy-panel-redirect h1::after {
-	content: '' !important;
+    content: '' !important;
 
 }
 
 #tracy-debug .tracy-panel-redirect h1::after {
-	content: '' !important;
+    content: '' !important;
 }
 
 .tracy-row {
     padding: 0 !important;
     margin: 0 !important;
+}
+
+.wrap_adminer_EditFieldLink {
+    position:relative;
+}
+
+.adminer_EditFieldLink {
+    opacity:0.4;
+    display:block;
+    width:10px;
+    height:13px;
+    position:absolute;
+    right:0;
+    top:2px;
+}
+
+.adminer_EditFieldLink:hover {
+    opacity:0.8;
+}
+
+.adminer_EditFieldLink svg {
+    display:block;
 }


### PR DESCRIPTION
The `<br>` before the icon was causing some empty space on some fields (e.g. CKEditor) and I thought the icon was a bit too dark and distracting so I made some minor changes, and moved the CSS into `styles.css`. See what you think.