### PR TITLE
Fix namespace parsing issue on module install

### DIFF
--- a/ProcessTracyAdminerRenderer.module.php
+++ b/ProcessTracyAdminerRenderer.module.php
@@ -1,86 +1,30 @@
-<?php
+<?php namespace ProcessWire;
 
-namespace ProcessWire {
+class ProcessTracyAdminerRenderer extends Process implements Module {
 
-    class ProcessTracyAdminerRenderer extends Process implements Module {
-
-        public static function getModuleInfo() {
-            return array(
-                'title' => __('Process Tracy Adminer Renderer', __FILE__),
-                'summary' => __('Adminer renderer for TracyDebugger.', __FILE__),
-                'author' => 'Adrian Jones',
-                'href' => 'https://processwire.com/talk/topic/12208-tracy-debugger/',
-                'version' => '2.0.3',
-                'autoload' => false,
-                'singular' => true,
-                'icon' => 'database',
-                'requires'  => 'ProcessWire>=2.7.2, PHP>=5.4.4, TracyDebugger',
-                'page' => array(
-                    'name' => 'adminer-renderer',
-                    'parent' => 'setup',
-                    'title' => 'Adminer Renderer',
-                    'status' => 'hidden'
-                )
-            );
-        }
-
-        public function ___execute() {
-            require_once __DIR__ . '/panels/Adminer/adminneo.php';
-            exit;
-        }
+    public static function getModuleInfo() {
+        return array(
+            'title' => __('Process Tracy Adminer Renderer', __FILE__),
+            'summary' => __('Adminer renderer for TracyDebugger.', __FILE__),
+            'author' => 'Adrian Jones',
+            'href' => 'https://processwire.com/talk/topic/12208-tracy-debugger/',
+            'version' => '2.0.3',
+            'autoload' => false,
+            'singular' => true,
+            'icon' => 'database',
+            'requires'  => 'ProcessWire>=2.7.2, PHP>=5.4.4, TracyDebugger',
+            'page' => array(
+                'name' => 'adminer-renderer',
+                'parent' => 'setup',
+                'title' => 'Adminer Renderer',
+                'status' => 'hidden'
+            )
+        );
     }
-}
 
-// global namespace so adminneo.php can call \adminneo_instance()
-namespace {
-
-    function adminneo_instance() {
-
-        foreach (glob(__DIR__.'/panels/Adminer/plugins/*.php') as $filename) {
-            require_once $filename;
-        }
-
-        $tracyConfig = \ProcessWire\wire('modules')->getModuleConfigData('TracyDebugger');
-
-        $plugins = [
-            new \AdminNeo\ExternalLoginPlugin(true),
-            new \AdminNeo\FrameSupportPlugin(["self"]),
-            new \AdminNeo\ProcessWirePlugin(),
-            new \AdminNeo\JsonDumpPlugin,
-            new \AdminNeo\JsonPreviewPlugin(
-                $tracyConfig['adminerJsonMaxLevel'],
-                $tracyConfig['adminerJsonInTable'],
-                $tracyConfig['adminerJsonInEdit'],
-                $tracyConfig['adminerJsonMaxTextLength']
-            ),
-            new \AdminNeo\XmlDumpPlugin,
-            new \AdminNeo\Bz2OutputPlugin,
-            new \AdminNeo\ZipOutputPlugin
-        ];
-
-        $config = [
-            "servers" => [
-                [
-                    "driver" => "mysql",
-                    "server" => \ProcessWire\wire('config')->dbHost .
-                        (\ProcessWire\wire('config')->dbPort ? ':' . \ProcessWire\wire('config')->dbPort : ''),
-                    "database" => \ProcessWire\wire('config')->dbName,
-                    "username" => \ProcessWire\wire('config')->dbUser,
-                    "password" => \ProcessWire\wire('config')->dbPass
-                ]
-            ],
-            "jsonValuesDetection" => true,
-            "jsonValuesAutoFormat" => true,
-            "preferSelection" => true,
-            "colorVariant" => $tracyConfig['adminerThemeColor'],
-            "cssUrls" => [
-                \ProcessWire\wire('config')->urls->root . 'site/modules/TracyDebugger/panels/Adminer/css/tweaks.css'
-            ],
-            "jsUrls" => [
-                \ProcessWire\wire('config')->urls->root . 'site/modules/TracyDebugger/panels/Adminer/scripts/tweaks.js'
-            ]
-        ];
-
-        return \AdminNeo\Admin::create($config, $plugins);
+    public function ___execute() {
+        require_once __DIR__ . '/panels/Adminer/adminneo-instance.php';
+        require_once __DIR__ . '/panels/Adminer/adminneo.php';
+        exit;
     }
 }

--- a/panels/Adminer/adminneo-instance.php
+++ b/panels/Adminer/adminneo-instance.php
@@ -1,0 +1,51 @@
+<?php
+// global namespace so adminneo.php can call \adminneo_instance()
+function adminneo_instance() {
+
+	foreach (glob(__DIR__.'/plugins/*.php') as $filename) {
+		require_once $filename;
+	}
+
+	$tracyConfig = \ProcessWire\wire('modules')->getModuleConfigData('TracyDebugger');
+
+	$plugins = [
+		new \AdminNeo\ExternalLoginPlugin(true),
+		new \AdminNeo\FrameSupportPlugin(["self"]),
+		new \AdminNeo\ProcessWirePlugin(),
+		new \AdminNeo\JsonDumpPlugin,
+		new \AdminNeo\JsonPreviewPlugin(
+			$tracyConfig['adminerJsonMaxLevel'],
+			$tracyConfig['adminerJsonInTable'],
+			$tracyConfig['adminerJsonInEdit'],
+			$tracyConfig['adminerJsonMaxTextLength']
+		),
+		new \AdminNeo\XmlDumpPlugin,
+		new \AdminNeo\Bz2OutputPlugin,
+		new \AdminNeo\ZipOutputPlugin
+	];
+
+	$config = [
+		"servers" => [
+			[
+				"driver" => "mysql",
+				"server" => \ProcessWire\wire('config')->dbHost .
+					(\ProcessWire\wire('config')->dbPort ? ':' . \ProcessWire\wire('config')->dbPort : ''),
+				"database" => \ProcessWire\wire('config')->dbName,
+				"username" => \ProcessWire\wire('config')->dbUser,
+				"password" => \ProcessWire\wire('config')->dbPass
+			]
+		],
+		"jsonValuesDetection" => true,
+		"jsonValuesAutoFormat" => true,
+		"preferSelection" => true,
+		"colorVariant" => $tracyConfig['adminerThemeColor'],
+		"cssUrls" => [
+			\ProcessWire\wire('config')->urls->root . 'site/modules/TracyDebugger/panels/Adminer/css/tweaks.css'
+		],
+		"jsUrls" => [
+			\ProcessWire\wire('config')->urls->root . 'site/modules/TracyDebugger/panels/Adminer/scripts/tweaks.js'
+		]
+	];
+
+	return \AdminNeo\Admin::create($config, $plugins);
+}


### PR DESCRIPTION
Hi @adrianbj,

When trying to install the namespaced version of TracyDebugger I faced this issue where ProcessWire couldn't handle the bracketed namespacing in [`ProcessTracyAdminerRenderer.module.php`](https://github.com/adrianbj/TracyDebugger/blob/6504d10677923324488d18d273edfc4aa0556191/ProcessTracyAdminerRenderer.module.php#L3):

![tracydebugger_error](https://github.com/user-attachments/assets/e2ec6791-da37-49b1-ab89-824b2f06986d)

So I instead put the `adminneo_instance()` in its own file next to the `adminneo.php` one. I named it `adminneo-instance.php` as it seems [AdminNeo can lookup for this file when the function doesn’t exist](https://github.com/adminneo-org/adminneo/blob/edd904016e489207a5f7b4c67c34993222e9e884/admin/include/bootstrap.inc.php#L132).

One small note: it seems you mistakenly updated the version from the current master’s one ([4.26.85](https://github.com/adrianbj/TracyDebugger/blob/be71dd970e6b05ab62e0cd3c01d365af5baf2ec7/TracyDebugger.module.php#L30) → [4.26.86](https://github.com/adrianbj/TracyDebugger/blob/6504d10677923324488d18d273edfc4aa0556191/TracyDebugger.module.php#L30))