### PR TITLE
Make Console template-vars replay resilient to context-dependent includes

### DIFF
--- a/includes/CodeProcessor.php
+++ b/includes/CodeProcessor.php
@@ -310,12 +310,28 @@ if(TracyDebugger::$allowedSuperuser || TracyDebugger::$validLocalUser || TracyDe
             $includedFiles = $tracySessionCache['includedFiles'];
             foreach($includedFiles as $key => $path) {
                 if($path != $this->file && $path != $page->template->filename) {
-                    include_once($path);
+                    // These files are replayed only for their function/class definitions, which
+                    // escape any scope; running them in a closure keeps their stray variables out
+                    // of the harvested template vars, and the catch stops one context-dependent
+                    // file (e.g. a partial expecting TemplateFile-injected variables, which can
+                    // fatal under PHP 8) from aborting the replay and the console run with it.
+                    try {
+                        (static function($p) { include_once($p); })($path);
+                    }
+                    catch(\Throwable $e) {
+                        // skip - this file's variables were never template-scoped anyway
+                    }
                 }
             }
             // template file is excluded above and included now, after all others, to prevent include errors to
             // relative file paths preventing access to all variables/functions - happens especially when filecompiler is off
-            include_once($page->template->filename);
+            // (kept in this scope deliberately: its variables are what we harvest below)
+            try {
+                include_once($page->template->filename);
+            }
+            catch(\Throwable $e) {
+                // degrade to no/partial template vars rather than killing the console run
+            }
 
             $templateVars = get_defined_vars();
             ob_end_clean();


### PR DESCRIPTION
## Summary

The Console panel's "access template vars" replay (`includes/CodeProcessor.php`) re-includes every file from the original page request so the template file's dependencies exist before it runs. Files that were rendered via `TemplateFile` in the real request — partials with injected variables (e.g. a consent banner partial expecting `$module`) — blow up when re-included bare, and under PHP 8 the cascade ends in a `TypeError` that aborts the replay loop, leaves the `ob_start()` buffer dangling, and breaks the console run (later includes never load, so the snippet fails on undefined functions with misleading errors).

Changes:

- **Dependency includes run inside a static closure with a `\Throwable` catch.** Function/class definitions still register globally (definitions escape scope; variables don't), stray variables from dependency files no longer leak into the harvested `get_defined_vars()`, and one context-dependent file degrades to a skip instead of killing everything after it.
- **The page template's own include keeps harvest scope** (its variables are the product) **but gets its own catch**, so a throwing template yields partial/no template vars rather than a dead console.

Found in production: after a frontend feature started rendering a PrivacyWire banner partial, every frontend-console run with template vars enabled failed with phantom `$module` errors plus `Call to undefined function` for functions whose defining file sat after the partial in the include list. The identical snippet worked from the admin console (replay doesn't run there).

## Test plan

- [ ] Frontend console + "access template vars" on a page whose render includes a context-dependent partial: snippet runs, no replay abort, template vars present
- [ ] Same page, confirm a function defined in a prepended functions file is callable from the snippet (definitions still global through the closure)
- [ ] Verify a variable defined only inside a TemplateFile-rendered partial does NOT appear in console template vars (leak fixed)
- [ ] Admin console unchanged
- [ ] `php -l includes/CodeProcessor.php` clean